### PR TITLE
catch error if unhfs fails

### DIFF
--- a/src/main/java/io/takari/jdkget/JdkGetter.java
+++ b/src/main/java/io/takari/jdkget/JdkGetter.java
@@ -70,7 +70,9 @@ public class JdkGetter {
       output.info("We already have a copy of " + jdkImage);
     }
     
-    getExtractor(arch).extractJdk(jdkVersion, jdkImage, outputDirectory, inProcessDirectory, output);
+    if (!getExtractor(arch).extractJdk(jdkVersion, jdkImage, outputDirectory, inProcessDirectory, output)) {
+      throw new IOException("Failed to extract JDK from " + jdkImage);
+    }
     
     FileUtils.deleteDirectory(inProcessDirectory);
   }

--- a/src/main/java/io/takari/jdkget/osx/OsxJDKExtractor.java
+++ b/src/main/java/io/takari/jdkget/osx/OsxJDKExtractor.java
@@ -33,10 +33,16 @@ public class OsxJDKExtractor implements IJdkExtractor {
     output.info("Extracting osx dmg image into " + outputDirectory);
     
     // DMG <-- XAR <-- GZ <-- CPIO
-    UnHFS.unhfs(jdkDmg, inProcessDirectory);
+    try {
+      UnHFS.unhfs(jdkDmg, inProcessDirectory);
+    } catch (Exception e) {
+      output.error(e.getMessage());
+      return false;
+    }
 
     List<File> files = FileUtils.getFiles(inProcessDirectory, "**/*.pkg", null, true);
     // validate
+    
     File jdkPkg = files.get(0);
     XarFile xarFile = new XarFile(jdkPkg);
     for (XarEntry entry : xarFile.getEntries()) {

--- a/src/main/java/io/takari/jdkget/osx/UnHFS.java
+++ b/src/main/java/io/takari/jdkget/osx/UnHFS.java
@@ -157,8 +157,7 @@ public class UnHFS {
     }
 
     if (fact == null) {
-      System.err.println("No HFS file system found.");
-      return;
+      throw new RuntimeIOException("No HFS file system found.");
     }
 
     CustomAttribute posixFilenamesAttribute = fact.getCustomAttribute("POSIX_FILENAMES");


### PR DESCRIPTION
had a problem with corrupted dmgs on a mac which lead to NPR.

Added some error propagation for the "fact == null" check in UnHFS.unhfs(...).
